### PR TITLE
Fix bluetooth percentage not showing on battery widget

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -94,6 +94,8 @@
                 android:exported="true">
             <intent-filter>
                 <action android:name="settings.intelligence.battery.action.FETCH_BATTERY_USAGE_DATA"/>
+                <action android:name="settings.intelligence.battery.action.FETCH_BLUETOOTH_BATTERY_DATA"/>
+                <action android:name="settings.intelligence.battery.action.CLEAR_BATTERY_CACHE_DATA"/>
             </intent-filter>
         </receiver>
 


### PR DESCRIPTION
* Add missing permissions

Change-Id: I70750baef9fab7e5cfc619899b37bbafc840b9f6
(cherry picked from commit https://github.com/PixelExperience/packages_apps_Settings/commit/91ee36292a986bcddb9ece1c335d88b33a920f85)